### PR TITLE
Let ShowSlideProcessor return if Slide is invalid

### DIFF
--- a/src/DeckHub.Shows/Messaging/ShowSlideProcessor.cs
+++ b/src/DeckHub.Shows/Messaging/ShowSlideProcessor.cs
@@ -46,6 +46,7 @@ namespace DeckHub.Shows.Messaging
             {
                 _logger.LogError("Invalid ShowSlide message received");
                 await _queueClient.CompleteAsync(lockToken).ConfigureAwait(false);
+                return;
             }
 
             try


### PR DESCRIPTION
Stop processing a `ShowSlide` message if the `Slid` is invalid.  Resolves issue #1.